### PR TITLE
feat: add overload methods for PlayerManager that may need a realmId

### DIFF
--- a/Source/ACE.Server/Managers/PlayerManager.cs
+++ b/Source/ACE.Server/Managers/PlayerManager.cs
@@ -232,6 +232,19 @@ namespace ACE.Server.Managers
             return allPlayers;
         }
 
+        public static List<IPlayer> GetAllPlayers(ushort realmId)
+        {
+            var offlinePlayers = GetAllOffline(realmId);
+            var onlinePlayers = GetAllOnline(realmId);
+
+            var allPlayers = new List<IPlayer>();
+
+            allPlayers.AddRange(offlinePlayers);
+            allPlayers.AddRange(onlinePlayers);
+
+            return allPlayers;
+        }
+
         public static Dictionary<ulong, IPlayer> GetAccountPlayers(uint accountId)
         {
             playersLock.EnterReadLock();
@@ -258,6 +271,18 @@ namespace ACE.Server.Managers
                 playersLock.ExitReadLock();
             }
         }
+        public static int GetOfflineCount(ushort realmId)
+        {
+            playersLock.EnterReadLock();
+            try
+            {
+                return GetAllOffline(realmId).Count;
+            }
+            finally
+            {
+                playersLock.ExitReadLock();
+            }
+        }
 
         public static List<OfflinePlayer> GetAllOffline()
         {
@@ -277,12 +302,47 @@ namespace ACE.Server.Managers
             return results;
         }
 
+        public static List<OfflinePlayer> GetAllOffline(ushort realmId)
+        {
+            var results = new List<OfflinePlayer>();
+
+            playersLock.EnterReadLock();
+            try
+            {
+                foreach (var player in offlinePlayers.Values)
+                {
+                    var homeRealm = player.GetProperty(PropertyInt.HomeRealm);
+                    if (homeRealm != null && (ushort)homeRealm == realmId)
+                        results.Add(player);
+                }
+            }
+            finally
+            {
+                playersLock.ExitReadLock();
+            }
+
+            return results;
+        }
+
         public static int GetOnlineCount()
         {
             playersLock.EnterReadLock();
             try
             {
                 return onlinePlayers.Count;
+            }
+            finally
+            {
+                playersLock.ExitReadLock();
+            }
+        }
+
+        public static int GetOnlineCount(ushort realmId)
+        {
+            playersLock.EnterReadLock();
+            try
+            {
+                return GetAllOnline(realmId).Count;
             }
             finally
             {
@@ -357,6 +417,28 @@ namespace ACE.Server.Managers
 
             return results;
         }
+        public static List<Player> GetAllOnline(ushort realmId)
+        {
+            var results = new List<Player>();
+
+            playersLock.EnterReadLock();
+            try
+            {
+                foreach (var player in onlinePlayers.Values)
+                {
+                    var homeRealm = player.GetProperty(PropertyInt.HomeRealm);
+                    if (homeRealm != null && (ushort)homeRealm == realmId)
+                        results.Add(player);
+                }
+            }
+            finally
+            {
+                playersLock.ExitReadLock();
+            }
+
+            return results;
+        }
+
 
 
         /// <summary>


### PR DESCRIPTION
* GetOnlineCount, GetOfflineCount, GetAllOnline, GetAllOffline, GetAllPlayers

These are some overloads that may be useful, I'll be using them on Pourtide for things like `/pop` and other commands/utilities that may need to retrieve multiple players or player info depending on the realm they belong to.