### PR TITLE
add realm property to permit housing buys outside of primary instance

### DIFF
--- a/Source/ACE.Entity/Enum/Properties/RealmPropertyBool.cs
+++ b/Source/ACE.Entity/Enum/Properties/RealmPropertyBool.cs
@@ -83,7 +83,7 @@ will be moved to the parent realm.")]
 
         [Description("If enabled, players can purchase houses in instances other than the primary instance.")]
         [RealmPropertyBool(false)]
-        IgnoreHousingPrimaryInstanceRestriction = 14,
+        IgnoreHousingInstanceRestrictions = 14,
     }
 
     public static class RealmPropertyBoolExtensions

--- a/Source/ACE.Entity/Enum/Properties/RealmPropertyBool.cs
+++ b/Source/ACE.Entity/Enum/Properties/RealmPropertyBool.cs
@@ -80,6 +80,10 @@ will be moved to the parent realm.")]
         [Description("If enabled, classical instances will be active regardless of the character's location. This is not recommended for realms other than true solo-self-found realms, and is considered an advanced feature.")]
         [RealmPropertyBool(false)]
         ClassicalInstances_EnableForAllLandblocks_Dangerous = 13,
+
+        [Description("If enabled, players can purchase houses in instances other than the primary instance.")]
+        [RealmPropertyBool(false)]
+        IgnoreHousingPrimaryInstanceRestriction = 14,
     }
 
     public static class RealmPropertyBoolExtensions

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -1492,7 +1492,13 @@ Please report this to the ACRealms developer.");
 
         public WorldRealm WorldRealm => WorldRealmID.HasValue ? RealmManager.GetRealm(WorldRealmID, includeRulesets: true) : null;
         public bool IsPrimaryForWorldRealm => ShortInstanceID == 0;
-        public bool IsHomeInstanceForPlayer(Player player) => IsPrimaryForWorldRealm && player.HomeRealm == WorldRealmID;
+		
+        public bool IsHomeInstanceForPlayer(Player player)
+        {
+            if (RealmRuleset.GetProperty(RealmPropertyBool.IgnoreHousingPrimaryInstanceRestriction))
+                return player.HomeRealm == WorldRealmID;
+            return IsPrimaryForWorldRealm && player.HomeRealm == WorldRealmID;
+        }
 
         public class RealmShortcuts
         {

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -1492,13 +1492,8 @@ Please report this to the ACRealms developer.");
 
         public WorldRealm WorldRealm => WorldRealmID.HasValue ? RealmManager.GetRealm(WorldRealmID, includeRulesets: true) : null;
         public bool IsPrimaryForWorldRealm => ShortInstanceID == 0;
-		
-        public bool IsHomeInstanceForPlayer(Player player)
-        {
-            if (RealmRuleset.GetProperty(RealmPropertyBool.IgnoreHousingPrimaryInstanceRestriction))
-                return player.HomeRealm == WorldRealmID;
-            return IsPrimaryForWorldRealm && player.HomeRealm == WorldRealmID;
-        }
+        public bool IsHomeRealmForPlayer(Player player) => player.HomeRealm == WorldRealmID;
+        public bool IsHomeInstanceForPlayer(Player player) => IsPrimaryForWorldRealm && IsHomeRealmForPlayer(player);
 
         public class RealmShortcuts
         {

--- a/Source/ACE.Server/WorldObjects/Player_House.cs
+++ b/Source/ACE.Server/WorldObjects/Player_House.cs
@@ -32,11 +32,20 @@ namespace ACE.Server.WorldObjects
             //Console.WriteLine($"\n{Name}.HandleActionBuyHouse()");
             log.Info($"[HOUSE] {Name}.HandleActionBuyHouse()");
 
-            if (!CurrentLandblock.IsHomeInstanceForPlayer(this))
-            {
-                Session.Network.EnqueueSend(new GameMessageSystemChat("You may only purchase a house in your home realm.", ChatMessageType.Broadcast));
-                log.Info($"[HOUSE] {Name}.HandleActionBuyHouse(): Failed pre-purchase requirement - Not in home realm instance");
-                return;
+            if (RealmRuleset.GetProperty(RealmPropertyBool.IgnoreHousingInstanceRestrictions)){
+                if (!CurrentLandblock.IsHomeRealmForPlayer(this))
+                {
+                    Session.Network.EnqueueSend(new GameMessageSystemChat("You may only purchase a house in your home realm.", ChatMessageType.Broadcast));
+                    log.Info($"[HOUSE] {Name}.HandleActionBuyHouse(): Failed pre-purchase requirement - Not in home realm");
+                    return;
+                }
+            }else{
+                if (!CurrentLandblock.IsHomeInstanceForPlayer(this))
+                {
+                    Session.Network.EnqueueSend(new GameMessageSystemChat("You may only purchase a house in your home realm's primary instance.", ChatMessageType.Broadcast));
+                    log.Info($"[HOUSE] {Name}.HandleActionBuyHouse(): Failed pre-purchase requirement - Not in home realm instance");
+                    return;
+                }
             }
 
             // verify player doesn't already own a house


### PR DESCRIPTION
new boolean RealmProperty: IgnoreHousingInstanceRestrictions

if set, housing purchase still checks that player is in home realm, but does not prevent buying a house in non-primary instances